### PR TITLE
Update hashdrbg.d

### DIFF
--- a/src/dauth/hashdrbg.d
+++ b/src/dauth/hashdrbg.d
@@ -25,7 +25,7 @@ static if(!is(std.traits.TemplateArgsOf!(dummy!int)))
 
 version(Windows)
 {
-	import std.c.windows.windows;
+	import core.sys.windows.windows;
 	import core.runtime;
 }
 
@@ -78,7 +78,7 @@ struct SystemEntropyStream(string pathToRandom = defaultPathToRandom,
 
 	version(Windows)
 	{
-		import std.c.windows.windows;
+		import core.sys.windows.windows;
 		import core.runtime;
 
 		static assert(pathToRandom is null, "On Windows, SystemEntropyStream's pathToRandom must be null");


### PR DESCRIPTION
Replaced std.c.windows.windows with core.sys.windows.windows because it won't compile with newer DMD versions otherwise.

https://dlang.org/changelog/2.081.0.html#remove_std_c